### PR TITLE
Add simple full-stack template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,70 @@
-# test-codex
+<!-- README.md -->
+<!-- Describes the simple full-stack template for an AI Data Engineering SaaS. -->
+<!-- Not a place for detailed business logic or secrets. -->
+
+# AI Data Engineering SaaS Template
+
+This repository contains a very small Next.js frontend and a Python backend. The
+backend connects to Supabase. The goal is to give you a clean starting point
+without extra complexity.
+
+## Tech Stack
+
+- **Frontend:** [Next.js](https://nextjs.org) with React and
+  [Lucide React](https://lucide.dev) for icons.
+- **Backend:** [FastAPI](https://fastapi.tiangolo.com).
+- **Database:** [Supabase](https://supabase.com).
+- **Auth, Payments, Hosting, CI/CD:** not implemented to keep the template
+  minimal.
+
+## Folder Structure
+
+```
+frontend/
+  components/
+  pages/
+backend/
+  app/
+```
+
+The `frontend` folder holds the Next.js app. The `backend/app` folder contains
+FastAPI code. Add more modules here as you build your SaaS.
+
+## Running Locally
+
+1. Install Node.js and Python.
+2. In `frontend`, run `npm install` then `npm run dev`.
+3. In `backend`, create a virtual environment, install packages from
+   `requirements.txt`, and run `uvicorn app.main:app --reload`.
+
+You will need a Supabase project and credentials to connect to the database.
+Replace the placeholder values in `backend/app/main.py`.
+
+## UI Design Principles
+
+- Simple sans-serif font (default system fonts).
+- Minimal color palette to keep the interface calm.
+- Lucide icons for clarity.
+
+## File Structure Listing
+
+The tree command was not available in this environment, so the file listing was
+created manually:
+
+```
+.
+├── AGENTS.md
+├── README.md
+├── backend
+│   ├── app
+│   │   ├── __init__.py
+│   │   └── main.py
+│   └── requirements.txt
+└── frontend
+    ├── components
+    │   └── IconExample.tsx
+    ├── next.config.js
+    ├── package.json
+    └── pages
+        └── index.tsx
+```

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,0 +1,3 @@
+# backend/app/__init__.py
+# Marks backend/app as a Python package.
+# This file does not hold application logic.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,18 @@
+# backend/app/main.py
+# Defines the FastAPI app with a simple health check endpoint.
+# This file is not meant for heavy business logic.
+
+from fastapi import FastAPI
+from supabase import create_client, Client
+
+app = FastAPI()
+
+# TODO: Replace with your own Supabase credentials
+SUPABASE_URL = "https://your-project.supabase.co"
+SUPABASE_KEY = "public-anon-key"
+supabase: Client = create_client(SUPABASE_URL, SUPABASE_KEY)
+
+@app.get("/api/health")
+def health_check():
+    """Simple endpoint to verify the service is running."""
+    return {"status": "ok"}

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,7 @@
+# backend/requirements.txt
+# Lists Python packages required for the backend.
+# Not intended for global package management.
+
+fastapi==0.110.0
+uvicorn==0.29.0
+supabase==1.0.2

--- a/frontend/components/IconExample.tsx
+++ b/frontend/components/IconExample.tsx
@@ -1,0 +1,12 @@
+// frontend/components/IconExample.tsx
+// Demonstrates how to use Lucide icons in a React component.
+// This file is not meant for heavy UI logic.
+
+import { FC } from 'react';
+import { Database } from 'lucide-react';
+
+const IconExample: FC = () => {
+  return <Database aria-label="Database icon" />;
+};
+
+export default IconExample;

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,0 +1,10 @@
+// frontend/next.config.js
+// Configures Next.js for the project. Keep it minimal and simple.
+// This file is not for adding complex webpack plugins.
+
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+module.exports = nextConfig;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "ai-data-saas-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "13.5.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "lucide-react": "0.292.0"
+  }
+}

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,0 +1,20 @@
+// frontend/pages/index.tsx
+// The main page of the Next.js app. Renders a simple hello world with an icon.
+// This file does not contain complex business logic.
+
+import { FC } from 'react';
+import { Sparkles } from 'lucide-react';
+
+const Home: FC = () => {
+  return (
+    <main style={{ padding: '2rem', fontFamily: 'Arial, sans-serif' }}>
+      <h1>
+        <Sparkles style={{ marginRight: '0.5rem' }} />
+        AI Data Engineering SaaS
+      </h1>
+      <p>Welcome to your Next.js frontend.</p>
+    </main>
+  );
+};
+
+export default Home;


### PR DESCRIPTION
## Summary
- add a minimal Next.js frontend using Lucide icons
- add a simple FastAPI backend wired for Supabase
- document the stack and structure

## Testing
- `python3 -m py_compile backend/app/main.py`

------
https://chatgpt.com/codex/tasks/task_e_683a76d4f21483338cf5a4b69d1ee3c5