### PR TITLE
Add starter OpenAI agents

### DIFF
--- a/frontend/agents/AnalyticsAgent.ts
+++ b/frontend/agents/AnalyticsAgent.ts
@@ -1,0 +1,19 @@
+// frontend/agents/AnalyticsAgent.ts
+// Provides an agent that answers analytics questions.
+// This file does not manage API routes or server setup.
+
+import OpenAI from 'openai';
+import { createAgent } from 'openai/agents';
+import { BarChart } from 'lucide-react';
+
+const openai = new OpenAI();
+
+// Agent specialized in data analytics queries
+export const analyticsAgent = createAgent({
+  client: openai,
+  instructions: 'Answer analytics-related questions.',
+  model: 'gpt-4-turbo'
+});
+
+// Icon representing analytics functionality
+export const AnalyticsIcon = BarChart;

--- a/frontend/agents/DataCleaningAgent.ts
+++ b/frontend/agents/DataCleaningAgent.ts
@@ -1,0 +1,19 @@
+// frontend/agents/DataCleaningAgent.ts
+// Defines a simple OpenAI agent that cleans data.
+// This file is not meant for complex workflows or UI logic.
+
+import OpenAI from 'openai';
+import { createAgent } from 'openai/agents';
+import { Broom } from 'lucide-react';
+
+const openai = new OpenAI();
+
+// Agent that focuses on cleaning CSV and JSON data
+export const dataCleaningAgent = createAgent({
+  client: openai,
+  instructions: 'Clean up and normalize data.',
+  model: 'gpt-4-turbo'
+});
+
+// Lucide icon to represent this agent in the UI
+export const DataCleaningIcon = Broom;

--- a/frontend/agents/ReportingAgent.ts
+++ b/frontend/agents/ReportingAgent.ts
@@ -1,0 +1,19 @@
+// frontend/agents/ReportingAgent.ts
+// Defines an agent that generates concise reports.
+// This file does not handle authentication or storage.
+
+import OpenAI from 'openai';
+import { createAgent } from 'openai/agents';
+import { FileText } from 'lucide-react';
+
+const openai = new OpenAI();
+
+// Agent for summarizing data into short reports
+export const reportingAgent = createAgent({
+  client: openai,
+  instructions: 'Create short summary reports.',
+  model: 'gpt-4-turbo'
+});
+
+// Icon to use when showing this agent in React components
+export const ReportingIcon = FileText;

--- a/frontend/agents/SupportAgent.ts
+++ b/frontend/agents/SupportAgent.ts
@@ -1,0 +1,19 @@
+// frontend/agents/SupportAgent.ts
+// Creates an agent for simple chat-based support.
+// This file does not include advanced routing or state management.
+
+import OpenAI from 'openai';
+import { createAgent } from 'openai/agents';
+import { MessageSquare } from 'lucide-react';
+
+const openai = new OpenAI();
+
+// Agent that answers basic customer questions
+export const supportAgent = createAgent({
+  client: openai,
+  instructions: 'Provide short customer support replies.',
+  model: 'gpt-4-turbo'
+});
+
+// Icon for representing support conversations
+export const SupportIcon = MessageSquare;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,8 @@
     "next": "13.5.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "lucide-react": "0.292.0"
+    "lucide-react": "0.292.0",
+    "openai": "^4.29.0",
+    "openai-agents": "^0.1.0"
   }
 }


### PR DESCRIPTION
## Summary
- add four simple OpenAI agents under `frontend/agents`
- include lucide icons for each agent
- extend the frontend package dependencies with OpenAI packages

## Testing
- `npm install` *(fails: 403 Forbidden - registry access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6871e4c16ff08333bf3448378a9f1944