### PR TITLE
Simplify README and frontend for AI mobile template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 <!-- README.md -->
-<!-- Describes the simple full-stack template for an AI Data Engineering SaaS. -->
+<!-- Describes the simple full-stack template for an AI Android Mobile class. -->
 <!-- Not a place for detailed business logic or secrets. -->
 
-# AI Data Engineering SaaS Template
+# AI Android Mobile Class Template
 
-This repository contains a very small Next.js frontend and a Python backend. The
-backend connects to Supabase. The goal is to give you a clean starting point
-without extra complexity.
+This repository contains a small Next.js frontend and a Python backend. The
+backend connects to Supabase. The goal is to give you a clean starting point for
+mobile AI coursework without extra complexity.
 
 ## Tech Stack
 
@@ -28,7 +28,7 @@ backend/
 ```
 
 The `frontend` folder holds the Next.js app. The `backend/app` folder contains
-FastAPI code. Add more modules here as you build your SaaS.
+FastAPI code. Add more modules here as you build your class projects.
 
 ## Running Locally
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ai-data-saas-frontend",
+  "name": "ai-mobile-class-frontend",
   "version": "0.1.0",
   "private": true,
   "scripts": {

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -10,7 +10,7 @@ const Home: FC = () => {
     <main style={{ padding: '2rem', fontFamily: 'Arial, sans-serif' }}>
       <h1>
         <Sparkles style={{ marginRight: '0.5rem' }} />
-        AI Data Engineering SaaS
+        AI Android Mobile Class
       </h1>
       <p>Welcome to your Next.js frontend.</p>
     </main>


### PR DESCRIPTION
## Summary
- rename the template to **AI Android Mobile Class Template**
- update the main page heading
- adjust frontend package name
- clarify the setup in README

## Testing
- `node -v`
- `python3 --version`

------
https://chatgpt.com/codex/tasks/task_e_6871e448b0ac83338526dfbbd9110a89